### PR TITLE
🤿  feat: add support to rn-masked-text 🎭 

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -19,6 +19,12 @@ const App = () => {
           value={email}
           styleLabel={{fontWeight: '600'}}
           styleBodyContent={styles.bodyContent}
+          mask="cel-phone"
+          maskOptions={{
+            maskType: 'BRL',
+            withDDD: true,
+            dddMask: '(99) ',
+          }}
         />
         <AnimatedInput
           placeholder="Password"

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-animated-input": "file:../react-native-animated-input-1.0.0.tgz"
+    "react-native-animated-input": "../react-native-animated-input-1.0.0.tgz",
+    "react-native-masked-text": "^1.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2110,6 +2110,11 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-and-time@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
+  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+
 dayjs@^1.8.15:
   version "1.8.20"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.20.tgz#724a5cb6ad1f6fc066b0bd9a800dedcc7886f19e"
@@ -5426,6 +5431,14 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
+react-native-masked-text@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-masked-text/-/react-native-masked-text-1.13.0.tgz#533fde8c45ccbaa1d6b0df30bf19b84b4ace3de3"
+  integrity sha512-iMku5Ky6DP4fTRosjsYNJOhH8yoBQCzRALBdv1wVDKmCBQhhVE8RHr5EW4SNUjkYTZL473sDdEKl4NI948q9FQ==
+  dependencies:
+    date-and-time "0.9.0"
+    tinymask "1.0.2"
+
 react-native@0.61.5:
   version "0.61.5"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.61.5.tgz#6e21acb56cbd75a3baeb1f70201a66f42600bba8"
@@ -6389,6 +6402,11 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
+
+tinymask@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinymask/-/tinymask-1.0.2.tgz#df3775a94087b0d3d056c256e8923c01b7ec0941"
+  integrity sha1-3zd1qUCHsNPQVsJW6JI8AbfsCUE=
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/src/AnimatedInput/index.js
+++ b/src/AnimatedInput/index.js
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback, forwardRef } from "react";
-import { View, TextInput, Animated, Text } from "react-native";
-import styles from "./styles";
+import React, { useState, useEffect, useCallback, forwardRef } from 'react';
+import { View, TextInput, Animated, Text } from 'react-native';
+import { TextInputMask } from 'react-native-masked-text';
+import styles from './styles';
 
 const AnimatedTextInput = ({
   placeholder,
@@ -16,6 +17,8 @@ const AnimatedTextInput = ({
   styleError,
   styleContent,
   styleBodyContent,
+  mask,
+  maskOptions = {},
   ...others
 }) => {
   const [showInput, setShowInput] = useState(false);
@@ -36,15 +39,7 @@ const AnimatedTextInput = ({
       startAnimation();
     }
     animationView();
-  }, [
-    valid,
-    value,
-    animationView,
-    animationLabelFontSize,
-    animatedIsFocused,
-    startAnimation,
-    showInput,
-  ]);
+  }, [valid, value, animationView, animationLabelFontSize, animatedIsFocused, startAnimation, showInput]);
 
   const onBlur = () => {
     setInputFocus(false);
@@ -64,11 +59,9 @@ const AnimatedTextInput = ({
 
   const borderColor = () => {
     const borderStyle = {};
-    borderStyle.borderBottomColor =
-      styleBodyContent.borderBottomColor ||
-      styles.bodyContent.borderBottomColor;
+    borderStyle.borderBottomColor = styleBodyContent.borderBottomColor || styles.bodyContent.borderBottomColor;
     if (showError) {
-      borderStyle.borderBottomColor = errorColor || "#d32f2f";
+      borderStyle.borderBottomColor = errorColor || '#d32f2f';
     }
     return borderStyle;
   };
@@ -118,9 +111,7 @@ const AnimatedTextInput = ({
   }, [animatedIsFocused, inputFontSize, labelFontSize]);
 
   return (
-    <View
-      style={[styles.content, styleContent, { height: setContentHeight() }]}
-    >
+    <View style={[styles.content, styleContent, { height: setContentHeight() }]}>
       <Animated.View
         style={[
           styles.bodyContent,
@@ -143,46 +134,51 @@ const AnimatedTextInput = ({
           {showInput && (
             <View style={styles.toucheableLineContent}>
               <>{prefix}</>
-              <TextInput
-                {...others}
-                value={value}
-                pointerEvents={disabled ? "box-none" : "auto"}
-                selectionColor={styleInput.fontColor}
-                autoFocus
-                blurOnSubmit
-                editable={!disabled}
-                onBlur={() => onBlur()}
-                style={[styles.input, styleInput]}
-                onEndEditing={() => onBlur()}
-              />
+              {!!mask ? (
+                <TextInputMask
+                  {...others}
+                  value={value}
+                  pointerEvents={disabled ? 'box-none' : 'auto'}
+                  selectionColor={styleInput.fontColor}
+                  autoFocus
+                  blurOnSubmit
+                  editable={!disabled}
+                  onBlur={() => onBlur()}
+                  style={[styles.input, styleInput]}
+                  onEndEditing={() => onBlur()}
+                  type={mask || 'cpf'}
+                  options={maskOptions}
+                />
+              ) : (
+                <TextInput
+                  {...others}
+                  value={value}
+                  pointerEvents={disabled ? 'box-none' : 'auto'}
+                  selectionColor={styleInput.fontColor}
+                  autoFocus
+                  blurOnSubmit
+                  editable={!disabled}
+                  onBlur={() => onBlur()}
+                  style={[styles.input, styleInput]}
+                  onEndEditing={() => onBlur()}
+                />
+              )}
             </View>
           )}
         </View>
         <View style={styles.sufix}>{sufix}</View>
       </Animated.View>
-      {showError && (
-        <Text
-          style={[
-            styles.error,
-            errorColor && { color: errorColor },
-            styleError,
-          ]}
-        >
-          {errorText}
-        </Text>
-      )}
+      {showError && <Text style={[styles.error, errorColor && { color: errorColor }, styleError]}>{errorText}</Text>}
     </View>
   );
 };
 
-const AnimatedInput = forwardRef((props, ref) => (
-  <AnimatedTextInput {...props} innerRef={ref} />
-));
+const AnimatedInput = forwardRef((props, ref) => <AnimatedTextInput {...props} innerRef={ref} />);
 
 AnimatedInput.defaultProps = {
   valid: true,
   disabled: false,
-  value: "",
+  value: '',
   styleInput: {},
   styleBodyContent: {},
   styleLabel: {},


### PR DESCRIPTION
# 👁️ 😷 👁️  
- Adicionado a possibilidade de retornar um componente do `react-native-masked-text`, deixando o componente animado e com máscara caso seja preciso
- Para usar, o usuário precisa instalar o `react-native-animated-input` junto com a `react-native-masked-text `e passar como props `mask` a máscara que deseja
- Caso não queira usar uma máscara, a lib irá retornar o Text Input normal

